### PR TITLE
Update policy version from 16.04 to 20.04

### DIFF
--- a/gpstoolkit.apparmor
+++ b/gpstoolkit.apparmor
@@ -5,5 +5,5 @@
         "sensors",
         "keep-display-on"
     ],
-    "policy_version": 16.04
+    "policy_version": 20.04
 }


### PR DESCRIPTION
Now `clickable build` can be run without any problems :)